### PR TITLE
Fixed compile errors from lack of maintenance

### DIFF
--- a/.sbproj
+++ b/.sbproj
@@ -7,9 +7,12 @@
   "Schema": 1,
   "HasAssets": true,
   "AssetsPath": "",
-  "ResourcePaths": null,
+  "Resources": null,
+  "MenuResources": null,
   "HasCode": true,
   "CodePath": "code",
+  "PackageReferences": [],
+  "EditorReferences": null,
   "Metadata": {
     "ProjectTemplate": null,
     "Compiler": {
@@ -17,6 +20,7 @@
       "DefineConstants": "SANDBOX;ADDON;DEBUG",
       "NoWarn": "1701;1702;1591;",
       "Nullables": true
-    }
+    },
+    "CsProjName": ""
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# ⚠️ Archived ⚠️
+This was made for a very old version of s&box is likely broken due to several of s&box's major updates.
+# Original README Follows
 # sbox-icon-browser
  MaterialIcons browser as a Dock widget for the s&box editor.
 

--- a/code/IconBrowser.cs
+++ b/code/IconBrowser.cs
@@ -125,7 +125,7 @@ public class IconBrowser : Widget
 		if ( _copy != _last )
 		{
 			Log.Info( $"\"{name}\" copied to clipboard." );
-			Sandbox.UI.Clipboard.SetText( name );
+			EditorUtility.Clipboard.Copy( name );
 			_copy = obj;
 		}
 

--- a/code/IconBrowser.cs
+++ b/code/IconBrowser.cs
@@ -38,7 +38,7 @@ public class IconBrowser : Widget
 		// init settings
 		Settings = new( SettingsPrefix );
 
-		SetLayout( LayoutMode.TopToBottom );
+		Layout = Layout.Column();
 		Layout.Spacing = 0;
 
 		var top = Layout.AddRow();
@@ -125,7 +125,7 @@ public class IconBrowser : Widget
 		if ( _copy != _last )
 		{
 			Log.Info( $"\"{name}\" copied to clipboard." );
-			Clipboard.Copy( $"{name}" );
+			Sandbox.UI.Clipboard.SetText( name );
 			_copy = obj;
 		}
 


### PR DESCRIPTION
There wasn't a pain day, but a few breaking changes were made that caused this tool to break.

Fixes:
1. `SetLayout` -> `Layout = ...`
2. `LayoutMode.TopToBottom` -> `Layout.Column()`
3. `Clipboard.Copy` -> `EditorUtility.Clipboard.Copy`

Also converted from the archaic `.addon` to the new `.sbproj` file.